### PR TITLE
Avoid PHP warning in case of disabled highlighting

### DIFF
--- a/Classes/Flowpack/SearchPlugin/EelHelper/SearchArrayHelper.php
+++ b/Classes/Flowpack/SearchPlugin/EelHelper/SearchArrayHelper.php
@@ -23,12 +23,14 @@ class SearchArrayHelper implements ProtectedContextAwareInterface {
 	/**
 	 * Concatenate arrays or values to a new array
 	 *
-	 * @param array|mixed $array1 First array or value
-	 * @param array|mixed $array2 Second array or value
-	 * @param array|mixed $array_ Optional variable list of additional arrays / values
+	 * @param array|mixed $arrays Arrays
 	 * @return array The array with concatenated arrays or values
 	 */
 	public function flatten($arrays) {
+		if (!is_array($arrays)) {
+			// might happen if $arrays is "null"
+			return $arrays;
+		}
 		$return = array();
 		array_walk_recursive($arrays, function($a) use (&$return) { $return[] = $a; });
 		return $return;


### PR DESCRIPTION
You might configure your indexer to not produce '_fulltext' for certain
documents, thus you won't get highlight array returned from ES.  And then
with the default setup this will produce an PHP warning in the "flatten()"
Eelhelper, and thus an exception:

Warning: array_walk_recursive() expects parameter 1 to be array, null given..

This fix just makes sure this doesn't break anything.
